### PR TITLE
Profit for each trade, trade optimisation

### DIFF
--- a/app/profit.js
+++ b/app/profit.js
@@ -125,6 +125,7 @@ exports.get = async function get(start, interval, end, enableTrades) {
 	const returnObj = {
 		profitTotal: tracker.profitTrack.getFormated(tracker.profitTrack.profit),
 		profitTimed: tracker.profitTrack.getFormated(tracker.profitTrack.profitTimed),
+		profitPlot: tracker.profitTrack.profitPlot,
 		numberOfTrades: iter,
 		overpriceProfit: tracker.profitTrack.getFormated(overpriceProfit),
 		keyValue: keyVal

--- a/app/profit.js
+++ b/app/profit.js
@@ -286,9 +286,8 @@ class itemTracker {
 		if (Object.prototype.hasOwnProperty.call(this.itemStock, sku)) { // have we bought this item already
 			if (this.itemStock[sku].count >= itemCount) {
 				this.itemStock[sku].count -= itemCount;
-				itemProfit += (this.convert(prices, rate) - this.itemStock[sku].price) * itemCount;
 				this.profitTrack.countProfit( (this.convert(prices, rate) - this.itemStock[sku].price) * itemCount, time);
-				return;
+				return (this.convert(prices, rate) - this.itemStock[sku].price) * itemCount;
 			} else {
 				itemProfit += (this.convert(prices, rate) - this.itemStock[sku].price) * this.itemStock[sku].count;
 				this.profitTrack.countProfit( (this.convert(prices, rate) - this.itemStock[sku].price) * this.itemStock[sku].count, time);

--- a/app/profit.js
+++ b/app/profit.js
@@ -6,11 +6,12 @@ const axios = require('axios');
 // TODO: Make this into class
 /**
  * @param {Number} start time to start plot
- * @param {Number} interval time interval to plot
- * @param {Number} end time to end plot
+ * @param {Number} interval time interval to plot, set to -1 or undefined to disable profit plot
+ * @param {Number} end time to end plot, set to -1 to disale profit timed and plot or undefined to disable just plot
+ * @param {Boolean} enableTrades enable return of profit data for each trade
  * @return {Object}
  */
-exports.get = async function get(start, interval, end) {
+exports.get = async function get(start, interval, end, enableTrades) {
 	const polldata = await fs.readJSON(paths.files.polldata);
 	const response = await axios(
 		{
@@ -44,12 +45,17 @@ exports.get = async function get(start, interval, end) {
 		return a - b;
 	});
 
+	const tradeProfits = {};
+
 	let iter = 0; // to keep track of how many trades are accepted
 	for (let i = 0; i < trades.length; i++) { // TODO: ADMIN TRADES
 		const trade = trades[i];
 		if (!(trade.handledByUs === true && trade.isAccepted === true)) {
 			continue;// trade was not accepted, go to next trade
 		}
+
+		let tradeProfit = 0;
+
 		iter++;
 		let isGift = false;
 		if (!Object.prototype.hasOwnProperty.call(trade, 'dict')) {
@@ -92,7 +98,7 @@ exports.get = async function get(start, interval, end) {
 					}
 					const prices = trade.prices[sku].buy;
 
-					tracker.boughtItem(itemCount, sku, prices, trade.value.rate, trade.time);
+					tradeProfit += tracker.boughtItem(itemCount, sku, prices, trade.value.rate, trade.time);
 				}
 			}
 		}
@@ -105,23 +111,26 @@ exports.get = async function get(start, interval, end) {
 						continue; // item is not in pricelist, so we will just skip it
 					}
 					const prices = trade.prices[sku].sell;
-					tracker.soldItem(itemCount, sku, prices, trade.value.rate, trade.time);
+					tradeProfit += tracker.soldItem(itemCount, sku, prices, trade.value.rate, trade.time);
 				}
 			}
 		}
 		if (!isGift) { // calculate overprice profit
+			tradeProfit += tracker.convert(trade.value.their, trade.value.rate) - tracker.convert(trade.value.our, trade.value.rate);
 			overpriceProfit += tracker.convert(trade.value.their, trade.value.rate) - tracker.convert(trade.value.our, trade.value.rate);
 			tracker.profitTrack.countProfit( tracker.convert(trade.value.their, trade.value.rate) - tracker.convert(trade.value.our, trade.value.rate), trade.time);
 		}
+		tradeProfits[trade.id] = tracker.profitTrack.getFormated(tradeProfit);
 	}
-	return {
+	const returnObj = {
 		profitTotal: tracker.profitTrack.getFormated(tracker.profitTrack.profit),
 		profitTimed: tracker.profitTrack.getFormated(tracker.profitTrack.profitTimed),
-		profitPlot: tracker.profitTrack.profitPlot,
 		numberOfTrades: iter,
 		overpriceProfit: tracker.profitTrack.getFormated(overpriceProfit),
 		keyValue: keyVal
 	};
+	if (enableTrades) returnObj['tradeProfits'] = tradeProfits;
+	return returnObj;
 };
 
 /**
@@ -229,18 +238,21 @@ class itemTracker {
 	 * @param {Object} prices prices for this item
 	 * @param {Number} rate key rate
 	 * @param {Number} time
+	 * @return {Number} profit made on this item
 	 */
 	boughtItem(itemCount, sku, prices, rate, time) {
+		let itemProfit = 0;
 		if (Object.prototype.hasOwnProperty.call(this.overItems, sku)) { // if record for this item exists in overItems check it
 			if (this.overItems[sku].count > 0) {
 				if (this.overItems[sku].count >= itemCount) {
 					this.overItems[sku].count -= itemCount;
 					this.profitTrack.countProfit( (this.overItems[sku].price - this.convert(prices, rate)) * itemCount, time);
-					return; // everything is already sold no need to add to stock
+					return (this.overItems[sku].price - this.convert(prices, rate)) * itemCount; // everything is already sold no need to add to stock
 				} else {
 					const itemsOverOverItems = itemCount - this.overItems[sku].count;
 					this.overItems[sku].count = 0;
 					this.profitTrack.countProfit( (this.overItems[sku].price - this.convert(prices, rate)) * (itemCount - itemsOverOverItems), time);
+					itemProfit += (this.overItems[sku].price - this.convert(prices, rate)) * (itemCount - itemsOverOverItems);
 					itemCount = itemsOverOverItems;
 				}
 			}
@@ -256,6 +268,7 @@ class itemTracker {
 				price: this.convert(prices, rate)
 			};
 		}
+		return itemProfit;
 	}
 
 	/**
@@ -265,14 +278,18 @@ class itemTracker {
 	 * @param {Object} prices prices for item sold
 	 * @param {Number} rate key rate
 	 * @param {Number} time time of trade
+	 * @return {Number} profit made on this item
 	 */
 	soldItem(itemCount, sku, prices, rate, time) {
+		let itemProfit = 0;
 		if (Object.prototype.hasOwnProperty.call(this.itemStock, sku)) { // have we bought this item already
 			if (this.itemStock[sku].count >= itemCount) {
 				this.itemStock[sku].count -= itemCount;
+				itemProfit += (this.convert(prices, rate) - this.itemStock[sku].price) * itemCount;
 				this.profitTrack.countProfit( (this.convert(prices, rate) - this.itemStock[sku].price) * itemCount, time);
 				return;
 			} else {
+				itemProfit += (this.convert(prices, rate) - this.itemStock[sku].price) * this.itemStock[sku].count;
 				this.profitTrack.countProfit( (this.convert(prices, rate) - this.itemStock[sku].price) * this.itemStock[sku].count, time);
 				itemCount -= this.itemStock[sku].count;
 				this.itemStock[sku].count = 0;
@@ -289,6 +306,7 @@ class itemTracker {
 				price: this.convert(prices, rate)
 			};
 		}
+		return itemProfit;
 	}
 
 	/**

--- a/app/routes/trades.js
+++ b/app/routes/trades.js
@@ -14,16 +14,9 @@ router.get('/', (req, res) => {
 			return;
 		}
 	
-		trades.get()
-			.then((data) => {
-				res.render('trades', {
-					data: data,
-					polldata: true
-				});
-			})
-			.catch((err) => {
-				throw err;
-			});
+		res.render('trades', {
+			polldata: true
+		});
 	} else {
 		if (!fs.existsSync(paths.files.polldata)) {
 			res.json({
@@ -32,7 +25,7 @@ router.get('/', (req, res) => {
 			return;
 		}
 	
-		trades.get()
+		trades.get(Number(req.query.first), Number(req.query.count), Number(req.query.dir)==1)
 			.then((data) => {
 				res.json({
 					success: 1,

--- a/app/trades.js
+++ b/app/trades.js
@@ -20,6 +20,7 @@ exports.get = async function(first, count, descending) {
 		ret.id = key;
 		return ret;
 	});
+	const tradeCount = tradeList.length;
 	tradeList = tradeList.sort((a, b)=>{
 		a = a.finishTimestamp;
 		b = b.finishTimestamp;
@@ -85,7 +86,8 @@ exports.get = async function(first, count, descending) {
 	});
 	return {
 		trades,
-		items
+		items,
+		tradeCount
 	};
 };
 

--- a/app/trades.js
+++ b/app/trades.js
@@ -4,65 +4,74 @@ const getName = require('../utils/getName');
 const data = require('./data');
 const moment = require('moment');
 const getImage = require('../utils/getImage');
-const SKU = require('tf2-sku');
+const profit = require('./profit');
 
 
-exports.get = function() {
-	return fs.readJSON(paths.files.polldata)
-		.then((polldata) => {
-			return Object.keys(polldata.offerData).map((key)=>{
-				const offer = polldata.offerData[key];
-				const ret = {
-					id: key,
-					lastChange: polldata.timestamps[key],
-					items: {
-						our: [],
-						their: []
-					},
-					action: offer.action,
-					partner: offer.partner,
-					accepted: offer.accepted,
-					time: offer.finishTimestamp,
-					datetime: moment.unix(Math.floor(offer.finishTimestamp/1000)).format('ddd D-M-YYYY HH:mm'),
-					value: offer.value,
-					prices: offer.prices,
-					accepted: offer.handledByUs === true && offer.isAccepted === true
-				};
-
-				if (typeof polldata.sent[key] != 'undefined') {
-					ret.lastState = data.ETradeOfferState[polldata.sent[key]];
-				} else if (typeof polldata.received[key] != 'undefined') {
-					ret.lastState = data.ETradeOfferState[polldata.received[key]];
-				}
-				if (Object.prototype.hasOwnProperty.call(offer, 'dict')) {
-					if (Object.keys(offer.dict.our).length > 0) {
-						Object.keys(offer.dict.our).forEach((k)=>{
-							ret.items.our.push(createTradeItem(k, offer.dict.our[k]));
-						});
+exports.get = async function() {
+	const polldata = await fs.readJSON(paths.files.polldata);
+	const profitData = (await profit.get(undefined, undefined, undefined, true)).tradeProfits;
+	const items = {};
+	const trades = Object.keys(polldata.offerData).map((key)=>{
+		const offer = polldata.offerData[key];
+		const ret = {
+			id: key,
+			items: {
+				our: [],
+				their: []
+			},
+			profit: Object.prototype.hasOwnProperty.call(profitData, key)?profitData[key]: '',
+			partner: offer.partner,
+			accepted: offer.accepted,
+			time: offer.finishTimestamp,
+			datetime: moment.unix(Math.floor(offer.finishTimestamp/1000)).format('ddd D-M-YYYY HH:mm'),
+			value: offer.value,
+			accepted: offer.handledByUs === true && offer.isAccepted === true
+		};
+		if (typeof polldata.sent[key] != 'undefined') {
+			ret.lastState = data.ETradeOfferState[polldata.sent[key]];
+		} else if (typeof polldata.received[key] != 'undefined') {
+			ret.lastState = data.ETradeOfferState[polldata.received[key]];
+		}
+		if (Object.prototype.hasOwnProperty.call(offer, 'dict')) {
+			if (Object.keys(offer.dict.our).length > 0) {
+				Object.keys(offer.dict.our).forEach((k)=>{
+					if (!Object.prototype.hasOwnProperty.call(items, k)) {
+						items[k] = createTradeItem(k);
 					}
-					if (Object.keys(offer.dict.their).length > 0) {
-						Object.keys(offer.dict.their).forEach((k)=>{
-							ret.items.their.push(createTradeItem(k, offer.dict.their[k]));
-						});
+					ret.items.our.push({
+						sku: k,
+						amount: offer.dict.our[k]
+					});
+				});
+			}
+			if (Object.keys(offer.dict.their).length > 0) {
+				Object.keys(offer.dict.their).forEach((k)=>{
+					if (!Object.prototype.hasOwnProperty.call(items, k)) {
+						items[k] = createTradeItem(k);
 					}
-				}
-
-				return ret;
-			});
-		});
+					ret.items.their.push({
+						sku: k,
+						amount: offer.dict.their[k]
+					});
+				});
+			}
+		}
+		return ret;
+	});
+	return {
+		trades,
+		items
+	};
 };
 
 /**
  * Creates item object
  * @param {String} sku 
- * @param {number} amount 
  * @return {Object} item object created
  */
-function createTradeItem(sku, amount) {
-	const item = SKU.fromString(sku);
-	item.sku = sku;
-	item.name = getName(item.sku);
-	item.style = getImage.getImageStyle(item.sku);
-	item.amount = amount;
-	return item;
+function createTradeItem(sku) {
+	return {
+		name: getName(sku),
+		style: getImage.getImageStyle(sku)
+	};
 }

--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -8,7 +8,8 @@ new Vue({
 		toShow: 50,
 		search: '',
 		order: 1,
-		acceptedOnly: 0
+		acceptedOnly: 0,
+		tradeCount: 0
 	},
 	methods: {
 		loadTrades: function(first=0, count=50, order=1) {
@@ -18,6 +19,7 @@ new Vue({
 					return response.json();
 				})
 				.then((data) => {
+					this.tradeCount = data.data.tradeCount;
 					if (first === 0) {
 						this.tradeList = data.data.trades;
 						this.items = data.data.items;
@@ -49,7 +51,7 @@ new Vue({
 		scroll() {
 			window.onscroll = () => {
 				const bottomOfWindow = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop) + window.innerHeight === document.documentElement.offsetHeight;
-				if (bottomOfWindow&&!loadLock) {
+				if (bottomOfWindow&&!loadLock&&toShow < this.tradeCount) {
 					const nuberToAdd = 50;
 					this.loadTrades((this.toShow), nuberToAdd, this.order);
 					this.toShow += nuberToAdd;

--- a/assets/js/trades.js
+++ b/assets/js/trades.js
@@ -2,6 +2,7 @@ new Vue({
 	el: '#app',
 	data: {
 		tradeList: [],
+		items: [],
 		toShow: 50,
 		search: '',
 		order: 1,
@@ -14,7 +15,8 @@ new Vue({
 					return response.json();
 				})
 				.then((data) => {
-					this.tradeList = data.data;
+					this.tradeList = data.data.trades;
+					this.items = data.data.items;
 				})
 				.catch((error) => {
 					console.error('Error:', error);

--- a/views/trades.ejs
+++ b/views/trades.ejs
@@ -49,32 +49,36 @@
       <div class="mt-3" id="tradeList">
         <div class="p-2 rounded border m-2 trade" v-for="trade in sortedTrades" :key="trade.id" :class="trade.accepted? '': 'declined'">
           <div>
-            {{trade.datetime}}: Trade <b>#{{trade.id}}</b> with <a :href="'https://steamcommunity.com/profiles/' + trade.partner"  target="_blank" class="steam-profile">{{trade.partner}}.</a> {{trade.accepted? '': ` Trade unsuccessfull, reason: ${trade.lastState}.`}}
+            {{trade.datetime}}: Trade <b>#{{trade.id}}</b> with <a :href="'https://steamcommunity.com/profiles/' + trade.partner"  target="_blank" class="steam-profile">{{trade.partner}}.</a>
+            {{trade.accepted? `Profit: ${trade.profit}`: ` Trade unsuccessfull, reason: ${trade.lastState}.`}}
           </div>
           <div class="float-right">{{trade.datetime}}</div>
           <div class="row">
             <div class="col item-list">
               <div>Our: {{trade.hasOwnProperty('value')? `${trade.value.our.keys} keys, ${trade.value.our.metal} metal`: ''}}</div>
-              <div class="item m-1 float-left" v-for="item in trade.items.our" :key="item.sku" :style="{ backgroundImage: `url(` + item.style.image_small + `)`, backgroundColor: item.style.quality_color, borderStyle: item.style.craftable? false : 'dashed',  borderColor: item.style.border_color}">
+              <div class="item m-1 float-left" v-for="item in trade.items.our" :key="item.sku" :style="{ backgroundImage: `url(` + items[item.sku].style.image_small + `)`, backgroundColor: items[item.sku].style.quality_color, borderStyle: items[item.sku].style.craftable? false : 'dashed',  borderColor: items[item.sku].style.border_color}">
                 <div class="info text-center font-weight-bold">
-                  {{item.name}}
-                </div>
-                <div class="item-count">
-                  <b>{{item.amount}}X</b>
-                </div>
-              </div>
-            </div>
-            <div class="col item-list">
-              <div>Their: {{trade.hasOwnProperty('value')? `${trade.value.their.keys} keys, ${trade.value.their.metal} metal`: ''}}</div>
-              <div class="item m-1 float-left" v-for="item in trade.items.their" :key="item.sku" :style="{ backgroundImage: `url(` + item.style.image_small + `)`, backgroundColor: item.style.quality_color, borderStyle: item.style.craftable? false : 'dashed', borderColor: item.style.border_color}">
-                <div class="info text-center font-weight-bold">
-                  {{item.name}}
+                  {{items[item.sku].name}}
                 </div>
                 <div class="item-count">
                   <b>{{item.amount}}X</b>
                 </div>
                 <div class="icon-stack">
-                  <b>{{item.style.killstreak}}</b>
+                  <b>{{items[item.sku].style.killstreak}}</b>
+                </div>
+              </div>
+            </div>
+            <div class="col item-list">
+              <div>Their: {{trade.hasOwnProperty('value')? `${trade.value.their.keys} keys, ${trade.value.their.metal} metal`: ''}}</div>
+              <div class="item m-1 float-left" v-for="item in trade.items.their" :key="item.sku" :style="{ backgroundImage: `url(` + items[item.sku].style.image_small + `)`, backgroundColor: items[item.sku].style.quality_color, borderStyle: items[item.sku].style.craftable? false : 'dashed', borderColor: items[item.sku].style.border_color}">
+                <div class="info text-center font-weight-bold">
+                  {{items[item.sku].name}}
+                </div>
+                <div class="item-count">
+                  <b>{{item.amount}}X</b>
+                </div>
+                <div class="icon-stack">
+                  <b>{{items[item.sku].style.killstreak}}</b>
                 </div>
               </div>
             </div>

--- a/views/trades.ejs
+++ b/views/trades.ejs
@@ -47,7 +47,7 @@
         </div>
       </div>
       <div class="mt-3" id="tradeList">
-        <div class="p-2 rounded border m-2 trade" v-for="trade in sortedTrades" :key="trade.id" :class="trade.accepted? '': 'declined'">
+        <div class="p-2 rounded border m-2 trade" v-for="trade in filteredTrades" :key="trade.id" :class="trade.accepted? '': 'declined'">
           <div>
             {{trade.datetime}}: Trade <b>#{{trade.id}}</b> with <a :href="'https://steamcommunity.com/profiles/' + trade.partner"  target="_blank" class="steam-profile">{{trade.partner}}.</a>
             {{trade.accepted? `Profit: ${trade.profit}`: ` Trade unsuccessfull, reason: ${trade.lastState}.`}}

--- a/views/trades.ejs
+++ b/views/trades.ejs
@@ -47,7 +47,7 @@
         </div>
       </div>
       <div class="mt-3" id="tradeList">
-        <div class="p-2 rounded border m-2 trade" v-for="(trade, index) in sortedTrades" :key="trade.id" :class="trade.accepted? '': 'declined'">
+        <div class="p-2 rounded border m-2 trade" v-for="trade in sortedTrades" :key="trade.id" :class="trade.accepted? '': 'declined'">
           <div>
             {{trade.datetime}}: Trade <b>#{{trade.id}}</b> with <a :href="'https://steamcommunity.com/profiles/' + trade.partner"  target="_blank" class="steam-profile">{{trade.partner}}.</a> {{trade.accepted? '': ` Trade unsuccessfull, reason: ${trade.lastState}.`}}
           </div>

--- a/views/trades.ejs
+++ b/views/trades.ejs
@@ -56,7 +56,7 @@
           <div class="row">
             <div class="col item-list">
               <div>Our: {{trade.hasOwnProperty('value')? `${trade.value.our.keys} keys, ${trade.value.our.metal} metal`: ''}}</div>
-              <div class="item m-1 float-left" v-for="item in trade.items.our" :key="item.sku" :style="{ backgroundImage: `url(` + items[item.sku].style.image_small + `)`, backgroundColor: items[item.sku].style.quality_color, borderStyle: items[item.sku].style.craftable? false : 'dashed',  borderColor: items[item.sku].style.border_color}">
+              <div class="item m-1 float-left" v-for="item in trade.items.our" :key="item.sku" :style="{ backgroundImage: `url(${items[item.sku].style.image_small}), url( ${items[item.sku].style.effect} )`, backgroundColor: items[item.sku].style.quality_color, borderStyle: items[item.sku].style.craftable? false : 'dashed',  borderColor: items[item.sku].style.border_color}">
                 <div class="info text-center font-weight-bold">
                   {{items[item.sku].name}}
                 </div>
@@ -70,7 +70,7 @@
             </div>
             <div class="col item-list">
               <div>Their: {{trade.hasOwnProperty('value')? `${trade.value.their.keys} keys, ${trade.value.their.metal} metal`: ''}}</div>
-              <div class="item m-1 float-left" v-for="item in trade.items.their" :key="item.sku" :style="{ backgroundImage: `url(` + items[item.sku].style.image_small + `)`, backgroundColor: items[item.sku].style.quality_color, borderStyle: items[item.sku].style.craftable? false : 'dashed', borderColor: items[item.sku].style.border_color}">
+              <div class="item m-1 float-left" v-for="item in trade.items.their" :key="item.sku" :style="{ backgroundImage: `url(${items[item.sku].style.image_small}), url( ${items[item.sku].style.effect} )`, backgroundColor: items[item.sku].style.quality_color, borderStyle: items[item.sku].style.craftable? false : 'dashed', borderColor: items[item.sku].style.border_color}">
                 <div class="info text-center font-weight-bold">
                   {{items[item.sku].name}}
                 </div>


### PR DESCRIPTION
Added profit made by each trade, it is not working too great, because there still are problems with profit calculator.
Made trades smaller by splitting them into trades and items, because items repeat a lot in trades.
Made trades to load in small chunks of 50 trades, load time of trades page for larger polldata decreased significantly.
#70 #69 